### PR TITLE
Additional buffer utils cleanup

### DIFF
--- a/packages/cpp-debug/package.json
+++ b/packages/cpp-debug/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@theia/core": "1.17.2",
     "@theia/debug": "1.17.2",
-    "base64-arraybuffer": "0.1.5",
     "long": "^4.0.0",
     "vscode-debugprotocol": "^1.48.0"
   },

--- a/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
+++ b/packages/cpp-debug/src/browser/editable-widget/memory-editable-table-widget.tsx
@@ -25,7 +25,6 @@ import * as Long from 'long';
 import { hexStrToUnsignedLong } from '../../common/util';
 import { MemoryWidget } from '../memory-widget/memory-widget';
 import { MemoryOptionsWidget } from '../memory-widget/memory-options-widget';
-import * as Array64 from 'base64-arraybuffer';
 import { DebugProtocol } from 'vscode-debugprotocol';
 
 export type EditableMemoryWidget = MemoryWidget<MemoryOptionsWidget, MemoryEditableTableWidget>;
@@ -197,7 +196,7 @@ export class MemoryEditableTableWidget extends MemoryTableWidget {
         for (const address of this.pendingMemoryEdits.keys()) {
             const { address: addressToSend, value: valueToSend } = this.composeByte(address, true);
             if (!addressesSubmitted.has(addressToSend)) {
-                const data = Array64.encode(new Uint8Array([parseInt(valueToSend, 16)]));
+                const data = Buffer.of(parseInt(valueToSend, 16)).toString('base64');
                 const writeMemoryArguments = { memoryReference: addressToSend.toString(), data };
                 yield this.memoryProvider.writeMemory?.(writeMemoryArguments) ?? Promise.resolve(undefined);
                 addressesSubmitted.add(addressToSend);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3583,7 +3583,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-arraybuffer@0.1.5, base64-arraybuffer@^0.1.5:
+base64-arraybuffer@^0.1.5:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   integrity sha1-c5JncZI7Whl0etZmqlzUv5xunOg=


### PR DESCRIPTION
Some additional cleanup that could be done with Buffers, allowing us to remove the direct dependency to `base64-arraybuffer`.